### PR TITLE
updates for Redhat based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,23 @@ This config file for whatever reason will not run if you try to add the "-- web"
 
 Also recommend you start logstash like "java -jar logstash-x.x.x-flatjar.jar agent -v -f /yourConf.conf"  The "-v" will give verbose output and help you debug issues. Also DON'T run in "-v" mode in a prod environment as you will end up outputting a ton of data to your console and/or logstash stdout capture file. (if you have one)
 
+Further note for Centos/Red Hat/Fedora Systems
+----------------------------------------------
 
+If logstash has been installed from the logstash repository (http://www.logstash.net/docs/1.4.2/repositories), follow these steps:
+
+  1. Set the path in logstash-modsecurity.conf to path => "/var/log/httpd/modsec_audit.log"
+  2. Copy logstash-modsecurity.conf to /etc/logstash/conf.d
+  3. Copy logstash_modsecurity_patterns to /opt/logstash/patterns/
+  4. Give read access to the logstash user on /var/log/httpd/modsec_audit.log
+
+     setfacl -m u:logstash:r /var/log/httpd/modsec_audit.log
+
+  5. Restart the logstash agent
+
+     systemctl restart logstash
+
+  6. Confirm mod_security messages are logged to standard output
+
+     tail -f /var/log/logstash/logstash.stdout
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ If logstash has been installed from the logstash repository (http://www.logstash
   3. Copy logstash_modsecurity_patterns to /opt/logstash/patterns/
   4. Give read access to the logstash user on /var/log/httpd/modsec_audit.log
 
-     setfacl -m u:logstash:r /var/log/httpd/modsec_audit.log
+     `setfacl -m u:logstash:r /var/log/httpd/modsec_audit.log
 
   5. Restart the logstash agent
 
-     systemctl restart logstash
+     `systemctl restart logstash
 
   6. Confirm mod_security messages are logged to standard output
 
-     tail -f /var/log/logstash/logstash.stdout
+     `tail -f /var/log/logstash/logstash.stdout
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ If logstash has been installed from the logstash repository (http://www.logstash
 3. Copy logstash_modsecurity_patterns to /opt/logstash/patterns/
 4. Give read access to the logstash user on /var/log/httpd/modsec_audit.log
 
-`setfacl -m u:logstash:r /var/log/httpd/modsec_audit.log
+`setfacl -m u:logstash:r /var/log/httpd/modsec_audit.log`
 
 5. Restart the logstash agent
 
-`systemctl restart logstash
+`systemctl restart logstash`
 
 6. Confirm mod_security messages are logged to standard output
 
-`tail -f /var/log/logstash/logstash.stdout
+`tail -f /var/log/logstash/logstash.stdout`
 

--- a/README.md
+++ b/README.md
@@ -34,18 +34,18 @@ Further note for Centos/Red Hat/Fedora Systems
 
 If logstash has been installed from the logstash repository (http://www.logstash.net/docs/1.4.2/repositories), follow these steps:
 
-  1. Set the path in logstash-modsecurity.conf to path => "/var/log/httpd/modsec_audit.log"
-  2. Copy logstash-modsecurity.conf to /etc/logstash/conf.d
-  3. Copy logstash_modsecurity_patterns to /opt/logstash/patterns/
-  4. Give read access to the logstash user on /var/log/httpd/modsec_audit.log
+1. Set the path in logstash-modsecurity.conf to path => "/var/log/httpd/modsec_audit.log"
+2. Copy logstash-modsecurity.conf to /etc/logstash/conf.d
+3. Copy logstash_modsecurity_patterns to /opt/logstash/patterns/
+4. Give read access to the logstash user on /var/log/httpd/modsec_audit.log
 
-     `setfacl -m u:logstash:r /var/log/httpd/modsec_audit.log
+`setfacl -m u:logstash:r /var/log/httpd/modsec_audit.log
 
-  5. Restart the logstash agent
+5. Restart the logstash agent
 
-     `systemctl restart logstash
+`systemctl restart logstash
 
-  6. Confirm mod_security messages are logged to standard output
+6. Confirm mod_security messages are logged to standard output
 
-     `tail -f /var/log/logstash/logstash.stdout
+`tail -f /var/log/logstash/logstash.stdout
 

--- a/logstash-modsecurity.conf
+++ b/logstash-modsecurity.conf
@@ -44,6 +44,7 @@ input {
     # that your server writes these log files in
     charset => "US-ASCII"
     path => "/path/to/your/modsec/audit/logs/*.log"
+    type => "mod_security"
   }
 }
 
@@ -59,6 +60,7 @@ filter {
     pattern => "^--[a-fA-F0-9]{8}-A--$"
     negate => true
     what => previous
+    type => "mod_security"
   }
 
 
@@ -431,14 +433,6 @@ output {
   # turn this off when ready to run in a 
   # real prod environment and get rid of the 
   # "-v" flag when starting logstash
-  stdout {
-    debug => true
-  }
+  stdout { }
   
-  # ideally you do NOT want to be running an 
-  # embedded elasticsearch in your logstash 
-  # process, you should be writing to a remote
-  # elasticsearch instance (i.e. at least another
-  # separate process from the logstash engine)
-  elasticsearch { embedded => true }
 }

--- a/logstash-modsecurity.conf
+++ b/logstash-modsecurity.conf
@@ -182,7 +182,7 @@ filter {
               match => {
                       "rawSectionF" => "(?<serverProtocol>.+?)\s(?<responseStatus>.+)$"
                       }
-              patterns_dir => "./patterns/modsecurity_grok_patterns"
+              patterns_dir => "./patterns/logstash_modsecurity_patterns"
       }
 
   # response section (WITH headers)
@@ -193,7 +193,7 @@ filter {
             match => {
                     "rawSectionF" => "(?<serverProtocol>.+?)\s(?<responseStatus>.+)\n{1}"
                     }
-            patterns_dir => "./patterns/modsecurity_grok_patterns"
+            patterns_dir => "./patterns/logstash_modsecurity_patterns"
     }
 
   } 


### PR DESCRIPTION
Here are some updates I have added to the README and config to get it working on the set up below. 

[root@www conf.d]# cat /etc/redhat-release 
Fedora release 18 (Spherical Cow)

[root@www conf.d]# rpm -qi logstash
Name        : logstash
Version     : 1.4.2
Release     : 1_2c0f5a1
Architecture: noarch
Install Date: Sat 07 Feb 2015 16:20:57 GMT
Group       : default
Size        : 141637420
License     : ASL 2.0
Signature   : RSA/SHA1, Tue 24 Jun 2014 14:47:22 BST, Key ID d27d666cd88e42b4
Source RPM  : logstash-1.4.2-1_2c0f5a1.src.rpm
Build Date  : Tue 24 Jun 2014 13:41:30 BST
Build Host  : oh-my
Relocations : / 
Packager    : <jls@oh-my>
Vendor      : Elasticsearch
URL         : http://logstash.net
Summary     : An extensible logging pipeline
Description :
An extensible logging pipeline

I discovered that logstash_modsecurity_patterns has to go in /opt/logstash/patterns rather than /etc/logstash/patterns so no need to change the pattern_dir, although it was set to modsecurity_grok_patterns instead of logstash_modsecurity_patterns in a couple of places. I have no idea if that was breaking anything though? :)

There are a few deprecated messages in the logs also but assuming you don't want to fix those at this stage to keep things compatible. Having said that, I did remove debug from the stdout { } in the output section.

Hope this is useful.

Ed
