### PR TITLE
Multiline codec instead of multiline filter

### DIFF
--- a/logstash-modsecurity.conf
+++ b/logstash-modsecurity.conf
@@ -45,24 +45,21 @@ input {
     charset => "US-ASCII"
     path => "/path/to/your/modsec/audit/logs/*.log"
     type => "mod_security"
+
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # merge all modsec events for a given entity into the same event.
+    # so essentially the modsec -Z marker is used as the splitter
+    # which is the end of each modsec logical event in the logfile
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    codec => multiline {
+      pattern => "^--[a-fA-F0-9]{8}-Z--$"
+      negate => true
+      what => previous
+    }
   }
 }
 
 filter {
-
-  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  # merge all modsec events for a given entity into the same event.
-  # so essentially the modsec -A marker is used as the splitter
-  # which is the start of each modsec logical event in the logfile
-  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  multiline {
-    pattern => "^--[a-fA-F0-9]{8}-Z--$"
-    negate => true
-    what => previous
-    type => "mod_security"
-  }
-
 
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Due to the complexity of the collapsed single string


### PR DESCRIPTION
Fixes #15

Changed description about the marker used as splitter (not -A anymore).