### PR TITLE
Set multiline codec parameter 'what' to 'next'. The pattern (section …

### DIFF
--- a/1000_input_stdin_example.conf
+++ b/1000_input_stdin_example.conf
@@ -6,7 +6,7 @@ input {
     codec => multiline {
       pattern => "^--[a-fA-F0-9]{8}-Z--$"
       negate => true
-      what => previous
+      what => next
     }
   }
 

--- a/1010_input_file_example.conf
+++ b/1010_input_file_example.conf
@@ -14,7 +14,7 @@ input {
       charset => "US-ASCII"
       pattern => "^--[a-fA-F0-9]{8}-Z--$"
       negate => true
-      what => previous
+      what => next
     }
   }
 }


### PR DESCRIPTION
…z) marks the end of an event, not the beginning. Otherwise the section z of the previous event will be assigned to the current event.

I found out about this while tracking down a different issue and adding some output to the ruby code.

It isn't really a bug, since section z doesn't contain any actual information, but it is correct to do it this way imho.