### PR TITLE
Remove field rawSectionZ

### DIFF
--- a/2500_filter_cleanup.conf
+++ b/2500_filter_cleanup.conf
@@ -5,7 +5,7 @@ filter {
     # Get rid of fields that we don't need anymore
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     mutate {
-      remove_field => [ "message", "raw_responseHeaders", "raw_requestHeaders"]
+      remove_field => [ "message", "raw_responseHeaders", "raw_requestHeaders", "rawSectionZ"]
     }
   }
 }


### PR DESCRIPTION
Field rawSectionZ is always empty, because the section delimiter
signals the end of the event. There is no data in this part.
No need to keep an empty field.