### PR TITLE
Compatibility with Logstash 7.2

### DIFF
--- a/2110_filter_section_k_parse_matchedRules.conf
+++ b/2110_filter_section_k_parse_matchedRules.conf
@@ -14,6 +14,7 @@ filter {
       # hack.. @see https://logstash.jira.com/browse/LOGSTASH-1331
       mutate {
         gsub => [ "rawSectionK", "\n", "~" ]
+        gsub => [ "rawSectionK", "(~+)", "~" ]
         split => [ "rawSectionK" , "~" ]
       }
 
@@ -24,7 +25,7 @@ filter {
       ruby {
         code => "
             secRuleIds = Array.new()
-            matchedRules_array = event.get('matchedRules').to_hash
+            matchedRules_array = event.get('matchedRules')
             matchedRules_array.each do |entry|
               if entry.match(/^SecRule /) and entry.match(/,id:/)
                 secRuleIds.push(/,id:(?<ruleId>\d+)/.match(entry)[:ruleId])


### PR DESCRIPTION
Previous version didn' t work for me in logstash 7. The to_hash method was not found and also not needed as the above split already creates an array.