### PR TITLE
Update 2089_filter_section_h_example_severities.conf

### DIFF
--- a/2089_filter_section_h_example_severities.conf
+++ b/2089_filter_section_h_example_severities.conf
@@ -11,7 +11,7 @@ filter {
     ruby {
       code => "
           modsecSeverities = Set.new
-          trailerMsgs = event.get('auditLogTrailer[messages]')
+          trailerMsgs = event.get('auditLogTrailer')['messages']
           trailerMsgs.each {|m|
             if m.key?('severity')
               modsecSeverities.add(m['severity'])


### PR DESCRIPTION
Changed line 
event.get('auditLogTrailer[messages]')
to
event.get('auditLogTrailer')['messages']

with previous line we got error: Ruby exception occurred: Invalid FieldReference: `auditLogTrailer[messages]